### PR TITLE
use mississippi module

### DIFF
--- a/lib/import.js
+++ b/lib/import.js
@@ -1,4 +1,4 @@
-var pump = require('pump')
+var miss = require('mississippi')
 var through = require('through2')
 
 module.exports = importStream
@@ -6,7 +6,7 @@ module.exports = importStream
 function importStream (jawn, opts) {
   if (!opts) opts = {}
   var writeStream = jawn.core.createWriteStream(opts)
-  var stream = pump(parseInputStream(opts), writeStream, function done (err) {
+  var stream = miss.pipe(parseInputStream(opts), writeStream, function done (err) {
     stream.id = writeStream.id
     console.log(err)
   })

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
     "fs": "0.0.2",
     "hypercore": "~1.8.0",
     "level": "~1.4.0",
+    "mississippi": "^1.2.0",
     "parse-input-stream": "^1.0.1",
     "path": "~0.12.7",
-    "pump": "^1.0.1",
     "tape": "~4.5.1",
     "through2": "^2.0.1"
   },


### PR DESCRIPTION
The [mississippi](https://github.com/maxogden/mississippi) module ties together a bunch of utilities like pump, pumpify, etc, giving them consistent names and [documentation](https://github.com/maxogden/mississippi).   To make our code more consistent, I recommend using it whenever appropriate rather than using pump, pumpify, etc directly.
